### PR TITLE
Remove LiteLoader and what used it. Closes GH-2, closes GH-10

### DIFF
--- a/listmods.txt
+++ b/listmods.txt
@@ -12,7 +12,6 @@
 1.7.10/GalacticraftCore-1.7-3.0.12.462.jar
 1.7.10/Hats-4.0.1.jar
 1.7.10/iChunUtil-4.2.3.jar
-1.7.10/liteloader-1.7.10.jar
 1.7.10/malisiscore-1.7.10-0.14.3.jar
 1.7.10/Mantle-1.7.10-0.3.2b.jar
 1.7.10/MicdoodleCore-1.7-3.0.12.462.jar

--- a/modlist.md
+++ b/modlist.md
@@ -118,7 +118,6 @@
 | [WailaPlugins](http://minecraft.curseforge.com/mc-mods/226119-waila-plugins) | 0.2.0-25 | tterrag | Addon for waila |
 | [Witching Gadgets](http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/2371563) | 1.1.10 | BluSunrize | It's a kind of magic |
 | [WorldEdit](http://wiki.sk89q.com/wiki/WorldEdit) | 6.1.1;no_git_id | sk89q<br/>wizjany<br/>TomyLobo | WorldEdit is an easy-to-use in-game world editor for Minecraft, supporting both single player and multiplayer. |
-| [WorldEditCUI](http://www.liteloader.com/mod/worldeditcui) | 1.7.10 |  | A graphical user interface for WorldEdit. WorldEditCUI is designed to assist in using WorldEdit, as well as preventing accidental errors. |
 ## Dependency/Core Mods
 | Mod | Version | Authors | Description |
 |-----|:-------:|:--------|:------------|

--- a/modlist.md
+++ b/modlist.md
@@ -34,7 +34,6 @@
 | [Dark Menagerie](http://minecraft.curseforge.com/mc-mods/224039-dark-menagerie) | 1.7.10-beta-3.1a | RWTema | This mod was created basically on a whim and out of curiosity with Minecraft's handling of entities and their rendering.  |
 | [DeathCounter](http://ichun.us/mods/death-counter/) | 5.0.0 | iChun | Simple death counter for servers. This mod adds a way for the server to calculate the number of deaths a player has (since its installation). It will also notify the player of the death count and ranking on the server |
 | [Doom like Dungeon's](http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/1293843) | 1.8.7 | BlackJar72 | Hard Core Dungeons |
-| [EiraIrc](http://www.minecraftforum.net/topic/1964989-) | 2.9.402 | Eira | This is an IRC connector that works on both client and server independently. It also adds some neat features like name colors, aliases and supports private IRC messages as well as Twitch chat. It also allows you to upload screenshots immediately to either DirectUpload or imgur! |
 | [Ender IO](http://www.minecraftforum.net/topic/1937619-) | 2.3.0.429_beta | crazypants | Compact conduits, painted things and access to your stuff through an eye of ender. |
 | [Ender Zoo](http://www.curse.com/mc-mods/minecraft/225247-ender-zoo) | 1.7.10-1.0.15.32 | crazypants | Ender Io's Mobs and more |
 | [EnhancedPortals](http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/1292751) | 3.0.12 | Alz454 | An advanced technological portal teleportation system |
@@ -115,7 +114,6 @@
 | [The Twilight Forest](http://www.minecraftforum.net/topic/561673) | 2.3.7 | Benimatic (Ben Mazur) | An enchanted forest dimension. |
 | [TrashSlot](http://www.curseforge.com/projects/235577/) | 1.0.31 | BlayTheNinth | Adds a trash slot to the inventory screen that allows deletion of unwanted items. |
 | [Traveller's Gear](http://minecraft.curseforge.com/mc-mods/224440-travellers-gear) | 1.16.6 | BluSunrize | RPG Inventories! Armorstands! Cross-Mod Interaction! Woohoo! |
-| [Voxel Map - No Radar (Zans)](http://www.planetminecraft.com/mod/zans-minimap/) | 1.0 | MamiyaOtaru | Mini-Map |
 | [Waila](http://www.mobiusstrip.eu/) | 1.5.10_1.7.10 | ProfMobius | WAILA (What Am I Looking At) is a mod that shows you what you are looking at.  |
 | [WailaPlugins](http://minecraft.curseforge.com/mc-mods/226119-waila-plugins) | 0.2.0-25 | tterrag | Addon for waila |
 | [Witching Gadgets](http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/2371563) | 1.1.10 | BluSunrize | It's a kind of magic |

--- a/modlist.md
+++ b/modlist.md
@@ -136,7 +136,6 @@
 | [GalacticraftCore](http://www.micdoodle8.com/mods/galacticraft) | 3.0.12.462 | micdoodle8 | Blast off to the stars. Makes a space base or a space station. Discover new worlds and exicting dungeons. |
 | [Hats](http://ichun.us/mods/hats/) | 4.0.1 | iChun | Adds a bunch of hats, as wells as the ability to add more, into Minecraft |
 | [iChunUtil](http://www.ichun.us/) | 4.2.3 | iChun | Shared library mod required by several of iChun's Mods. |
-| [Liteloader](http://www.liteloader.com/) | 1.7.10 |  | LiteLoader is a lightweight mod loader for Minecraft designed to provide simple, high-performance and reliable loader functionality for mods which don't need to modify game mechanics. |
 | [malisiscore](http://www.minecraftforum.net/forums/mapping-and-modding/minecraft-mods/2076338-) | 0.14.3 | Ordinastie | Core for Malisis mods |
 | [Mantle](http://www.minecraftforum.net/topic/1659892-) | 0.3.2b | SlimeKnights | Tinkers Construct Library |
 | [Micdoodle8 Core](http://www.micdoodle8.com/) | 3.0.12.462 | micdoodle8 | Provides core features of Micdoodle8's mods |


### PR DESCRIPTION
LiteLoader caused https://github.com/satoshinm/modpack/issues/2 and https://github.com/satoshinm/modpack/issues/10 and was only used for mods I wasn't using (VoxelMap and WorldEditCUI) so remove it