### PR TITLE
Sulfur: Minetweaker scripts reconcile Forgotten Nature + GregTech + Natura. Closes GH-84

### DIFF
--- a/scripts/ForgottenNature.zs
+++ b/scripts/ForgottenNature.zs
@@ -1,0 +1,1 @@
+<ForgottenNature:powders:0>.displayName = "Rock Sulfur";

--- a/scripts/ForgottenNature.zs
+++ b/scripts/ForgottenNature.zs
@@ -1,1 +1,5 @@
+import mods.ic2.Compressor;
+
 <ForgottenNature:powders:0>.displayName = "Rock Sulfur";
+<ForgottenNature:powders:0>.addTooltip("Compress 64 rock sulfur to 1 sulfur dust");
+Compressor.addRecipe(<gregtech:gt.metaitem.01:2022>, <ForgottenNature:powders:0> * 64);

--- a/scripts/TinkersConstruct.zs
+++ b/scripts/TinkersConstruct.zs
@@ -1,0 +1,1 @@
+<ore:dustSulfur>.add(<Natura:barleyFood:4>);

--- a/server/cauldron.yml
+++ b/server/cauldron.yml
@@ -107,48 +107,48 @@ world-settings:
     allow-tnt-punishment: true
     infinite-water-source: true
     entity-despawn-immediate: false
-    worldgen-gregtech-GT_Worldgenerator_Space: true
-    worldgen-ExtrabiomesXL-LeafPileGenerator: true
-    worldgen-Natura-BaseTreeWorldgen: true
-    worldgen-dldungeonsjdg-GenerationHandler: true
-    worldgen-ForgottenNature-FNWorldGenerator: true
-    worldgen-ExtrabiomesXL-VineGenerator: true
-    worldgen-ExtrabiomesXL-LegendOakGenerator: true
-    worldgen-TConstruct-SlimeIslandGen: true
-    worldgen-DraconicEvolution-DraconicWorldGenerator: true
-    worldgen-simplecore-OreGenerator: true
     worldgen-ImmersiveEngineering-IEWorldGen: true
-    worldgen-ExtrabiomesXL-MountainRidgeGenerator: true
-    worldgen-dimdoors-GatewayGenerator: true
-    worldgen-ExtrabiomesXL-CatTailGenerator: true
+    worldgen-Natura-BaseCloudWorldgen: true
+    worldgen-Natura-BaseTreeWorldgen: true
+    worldgen-TConstruct-SlimeIslandGen: true
+    worldgen-ExtrabiomesXL-MountainDesertGenerator: true
+    worldgen-simplecore-OreGenerator: true
+    worldgen-Forestry-WorldGenerator: true
+    worldgen-gregtech-GT_Worldgenerator: true
+    worldgen-Automagy-AutomagyWorldGenerator: true
+    worldgen-DraconicEvolution-DraconicWorldGenerator: true
+    worldgen-MrTJPCoreMod-SimpleGenHandler$: true
+    worldgen-ihl-IHLWorldGenerator: true
     worldgen-chisel-GeneratorChisel: true
-    worldgen-ExtrabiomesXL-EelGrassGenerator: true
-    worldgen-Natura-BaseCropWorldgen: true
-    worldgen-Thaumcraft-ThaumcraftWorldGenerator: true
+    worldgen-gregtech-GT_Worldgenerator_Space: true
+    worldgen-ExtrabiomesXL-VineGenerator: true
+    worldgen-ExtrabiomesXL-MountainRidgeGenerator: true
+    worldgen-Mystcraft-MystWorldGenerator: true
+    worldgen-ExtrabiomesXL-CatTailGenerator: true
+    worldgen-ForgottenNature-FNWorldGenerator: true
+    worldgen-rftools-GenericWorldGenerator: true
+    worldgen-ExtrabiomesXL-VanillaFloraGenerator: true
+    worldgen-BigReactors-BRWorldGenerator: true
+    worldgen-ExtrabiomesXL-FlowerGenerator: true
+    worldgen-ExtrabiomesXL-LegendOakGenerator: true
+    worldgen-factorization-DarkIronOreGenerator: true
     worldgen-TConstruct-TBaseWorldGenerator: true
-    worldgen-ExtrabiomesXL-OilGenerator: true
+    worldgen-appliedenergistics2-QuartzWorldGen: true
+    worldgen-appliedenergistics2-MeteoriteWorldGen: true
     worldgen-CoFHCore-WorldHandler: true
     worldgen-erebus-WorldGenAntlionMaze: true
-    worldgen-Automagy-AutomagyWorldGenerator: true
-    worldgen-gregtech-GT_Worldgenerator: true
-    worldgen-PneumaticCraft-WorldGeneratorPneumaticCraft: true
-    worldgen-ExtrabiomesXL-VanillaFloraGenerator: true
-    worldgen-factorization-DarkIronOreGenerator: true
-    worldgen-ExtrabiomesXL-MountainDesertGenerator: true
+    worldgen-dldungeonsjdg-GenerationHandler: true
+    worldgen-dimdoors-GatewayGenerator: true
+    worldgen-ExtrabiomesXL-OilGenerator: true
     worldgen-ExtrabiomesXL-QuicksandGenerator: true
-    worldgen-Forestry-WorldGenerator: true
-    worldgen-GalaxySpace-OverworldGenerator: true
     worldgen-thebetweenlands-WorldGenDruidCircle: true
-    worldgen-BigReactors-BRWorldGenerator: true
-    worldgen-appliedenergistics2-QuartzWorldGen: true
-    worldgen-ihl-IHLWorldGenerator: true
-    worldgen-Mystcraft-MystWorldGenerator: true
-    worldgen-MrTJPCoreMod-SimpleGenHandler$: true
-    worldgen-rftools-GenericWorldGenerator: true
-    worldgen-Natura-BaseCloudWorldgen: true
+    worldgen-Natura-BaseCropWorldgen: true
+    worldgen-PneumaticCraft-WorldGeneratorPneumaticCraft: true
+    worldgen-Thaumcraft-ThaumcraftWorldGenerator: true
     worldgen-IC2-IC2: true
-    worldgen-ExtrabiomesXL-FlowerGenerator: true
-    worldgen-appliedenergistics2-MeteoriteWorldGen: true
+    worldgen-ExtrabiomesXL-LeafPileGenerator: true
+    worldgen-ExtrabiomesXL-EelGrassGenerator: true
+    worldgen-GalaxySpace-OverworldGenerator: true
     worldgen-harvestcraft-PamGardenGenerator: true
     worldgen-harvestcraft-PamTreeGenerator: true
     worldgen-harvestcraft-PamBeeGenerator: true
@@ -191,6 +191,7 @@ world-environment-settings:
     keep-world-loaded: true
   miner:
     keep-world-loaded: false
+    enabled: true
   atum:
     keep-world-loaded: true
   outer:
@@ -201,6 +202,7 @@ world-environment-settings:
     keep-world-loaded: true
   pocket:
     keep-world-loaded: false
+    enabled: true
   limbo:
     keep-world-loaded: false
   personalpocket:

--- a/server/entities.yml
+++ b/server/entities.yml
@@ -22,99 +22,7 @@ world-settings:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
-    net-minecraft-entity-passive-EntityPig:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    tconstruct-world-entity-BlueSlime:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    drzhark-mocreatures-entity-passive-MoCEntityBunny:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    drzhark-mocreatures-entity-passive-MoCEntityHorse:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-minecraft-entity-monster-EntitySkeleton:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-minecraft-entity-monster-EntitySpider:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-minecraft-entity-monster-EntityZombie:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-lomeli-ec-entity-EntitySpiderCreeper:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    crazypants-enderzoo-entity-EntityConcussionCreeper:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    thaumcraft-common-entities-monster-EntityBrainyZombie:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    drzhark-mocreatures-entity-passive-MoCEntitySnake:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-minecraft-entity-monster-EntityCreeper:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-minecraft-entity-passive-EntitySheep:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-lomeli-ec-entity-EntityWindCreeper:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    chylex-hee-entity-mob-EntityMobEnderman:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    drzhark-mocreatures-entity-ambient-MoCEntityCricket:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    drzhark-mocreatures-entity-monster-MoCEntityWerewolf:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-lomeli-ec-entity-EntityWaterCreeper:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-lomeli-ec-entity-EntityElectricCreeper:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    drzhark-mocreatures-entity-ambient-MoCEntityBee:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    drzhark-mocreatures-entity-ambient-MoCEntityDragonfly:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    mods-railcraft-common-carts-EntityCartChest:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    drzhark-mocreatures-entity-passive-MoCEntityFox:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-lomeli-ec-entity-addon-EntityRFCreeper:
+    drzhark-mocreatures-entity-ambient-MoCEntitySnail:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
@@ -122,11 +30,23 @@ world-settings:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
-    net-minecraft-entity-monster-EntityWitch:
+    net-minecraft-entity-passive-EntityPig:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
-    net-minecraft-entity-passive-EntityBat:
+    drzhark-mocreatures-entity-passive-MoCEntityHorse:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-passive-MoCEntityBunny:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-ambient-MoCEntityMaggot:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    tconstruct-world-entity-BlueSlime:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
@@ -134,27 +54,39 @@ world-settings:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
-    drzhark-mocreatures-entity-ambient-MoCEntityFirefly:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
     drzhark-mocreatures-entity-ambient-MoCEntityFly:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
-    drzhark-mocreatures-entity-monster-MoCEntityWWolf:
+    drzhark-mocreatures-entity-ambient-MoCEntityCricket:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
-    drzhark-mocreatures-entity-monster-MoCEntityMiniGolem:
+    drzhark-mocreatures-entity-ambient-MoCEntityBee:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
-    net-lomeli-ec-entity-EntityFriendlyCreeper:
+    drzhark-mocreatures-entity-ambient-MoCEntityFirefly:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
-    net-lomeli-ec-entity-EntityPsyhicCreeper:
+    net-minecraft-entity-passive-EntitySheep:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-passive-MoCEntitySnake:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-ambient-MoCEntityDragonfly:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-item-EntityBoat:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-passive-MoCEntityFox:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
@@ -162,55 +94,11 @@ world-settings:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
-    net-lomeli-ec-entity-EntityEnderCreeper:
+    mods-railcraft-common-carts-EntityCartChest:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
-    net-lomeli-ec-entity-EntityStoneCreeper:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    drzhark-mocreatures-entity-monster-MoCEntitySilverSkeleton:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-lomeli-ec-entity-EntityIllusionCreeper:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-lomeli-ec-entity-EntitySolarCreeper:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-lomeli-ec-entity-EntityFireworkCreeper:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-lomeli-ec-entity-EntityIceCreeper:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-lomeli-ec-entity-EntityFireCreeper:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    drzhark-mocreatures-entity-monster-MoCEntityOgre:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    drzhark-mocreatures-entity-monster-MoCEntityHorseMob:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-lomeli-ec-entity-addon-EntityEUCreeper:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-lomeli-ec-entity-EntityEarthCreeper:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-lomeli-ec-entity-EntityCookieCreeper:
+    drzhark-mocreatures-entity-passive-MoCEntityPetScorpion:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
@@ -218,11 +106,55 @@ world-settings:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
-    net-minecraft-entity-item-EntityFallingBlock:
+    drzhark-mocreatures-entity-passive-MoCEntityBear:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
-    drzhark-mocreatures-entity-passive-MoCEntityMouse:
+    net-lomeli-ec-entity-EntityPsyhicCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-monster-EntityZombie:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-monster-EntitySkeleton:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-item-EntityXPOrb:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityIllusionCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    appeng-entity-EntityGrowingCrystal:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-item-EntityPainting:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    crazypants-enderzoo-entity-EntityConcussionCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    chylex-hee-entity-mob-EntityMobEnderman:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-monster-EntityCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-monster-MoCEntityWerewolf:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-addon-EntityEUCreeper:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
@@ -230,39 +162,7 @@ world-settings:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
-    drzhark-mocreatures-entity-aquatic-MoCEntityDolphin:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    drzhark-mocreatures-entity-aquatic-MoCEntityFishy:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    buildcraft-builders-EntityMechanicalArm:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-minecraft-entity-passive-EntityChicken:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-minecraft-entity-projectile-EntityArrow:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-minecraft-entity-passive-EntitySquid:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    mods-natura-entity-ImpEntity:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    biomesoplenty-common-entities-EntityGlob:
-      tick-no-players: false
-      never-ever-tick: false
-      tick-interval: 1
-    net-minecraft-entity-passive-EntityHorse:
+    net-minecraft-entity-monster-EntityPigZombie:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
@@ -270,11 +170,123 @@ world-settings:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
+    drzhark-mocreatures-entity-aquatic-MoCEntityFishy:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityEarthCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-aquatic-MoCEntityPiranha:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-passive-MoCEntityBird:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-passive-MoCEntityMole:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-passive-MoCEntityGoat:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-passive-EntityChicken:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-monster-EntitySpider:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityStoneCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntitySpiderCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    thaumcraft-common-entities-EntityAspectOrb:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityWaterCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-monster-MoCEntityWraith:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityCookieCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityWindCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityEnderCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-projectile-EntityArrow:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-passive-MoCEntityDuck:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-item-EntityFallingBlock:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    mods-natura-entity-ImpEntity:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    biomesoplenty-common-entities-EntityWasp:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-monster-MoCEntityHellRat:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
     crazypants-enderzoo-entity-EntityEnderminy:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
-    lumien-randomthings-Entity-EntitySoul:
+    drzhark-mocreatures-entity-monster-MoCEntityOgre:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityElectricCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-addon-EntityRFCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    thaumcraft-common-entities-monster-EntityBrainyZombie:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityFireCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-monster-EntitySlime:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityIceCreeper:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
@@ -282,11 +294,343 @@ world-settings:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
-    net-minecraft-entity-passive-EntityWolf:
+    drzhark-mocreatures-entity-monster-MoCEntityRat:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityFireworkCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-item-EntityMinecartHopper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-passive-MoCEntityKomodo:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-passive-MoCEntityElephant:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-monster-MoCEntitySilverSkeleton:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntitySolarCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    crazypants-enderzoo-entity-EntityWitherWitch:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-passive-EntityBat:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityLightCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-passive-MoCEntityBoar:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-monster-MoCEntityHorseMob:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-monster-MoCEntityMiniGolem:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityReverseCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-monster-MoCEntityGolem:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityDarkCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-monster-MoCEntityScorpion:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityBirthdayCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityHydrogenCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-monster-MoCEntityFlameWraith:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    lumien-randomthings-Entity-EntitySoul:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1
     net-minecraft-entity-item-EntityMinecartChest:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-passive-EntityVillager:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-item-EntityItemFrame:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    tconstruct-tools-entity-FancyEntityItem:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    crazypants-enderzoo-entity-EntityWitherCat:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-monster-EntityWitch:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-passive-MoCEntityCrocodile:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    thebetweenlands-entities-mobs-EntityDarkDruid:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    openblocks-common-entity-EntityHangGlider:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-monster-MoCEntityWWolf:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityMagmaCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    biomesoplenty-common-entities-EntityPhantom:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    mods-natura-entity-HeatscarSpider:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    mods-natura-entity-BabyHeatscarSpider:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    thaumcraft-common-entities-monster-EntityFireBat:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    erebus-entity-EntityBlackWidow:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    cofh-thermalfoundation-entity-monster-EntityBlitz:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    thaumcraft-common-entities-monster-EntityWisp:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    cofh-thermalfoundation-entity-monster-EntityBasalz:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    cofh-thermalfoundation-entity-projectile-EntityBlitzBolt:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    com-rwtema-menagerie-entities-Ents-EntityOliphant:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    mods-natura-entity-NitroCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    erebus-entity-EntityWebSling:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-passive-EntityWolf:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-passive-MoCEntityTurkey:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-passive-MoCEntityTurtle:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-passive-MoCEntityDeer:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    cofh-thermalfoundation-entity-projectile-EntityBasalzBolt:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityFriendlyCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    tconstruct-world-entity-KingBlueSlime:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-passive-MoCEntityMouse:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-passive-EntitySquid:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-monster-EntityCaveSpider:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    gregtech-common-entities-GTEntityArrow:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    lumien-randomthings-Entity-EntitySpirit:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    crazypants-enderzoo-entity-EntityFallenKnight:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityGhostCreeper:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    com-rwtema-menagerie-entities-Ents-EntityInfestedVillager:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    appeng-entity-EntityChargedQuartz:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-item-MoCEntityThrowableRock:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-passive-MoCEntityEnt:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    vazkii-botania-common-entity-EntityManaBurst:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    com-rwtema-menagerie-entities-Ents-EntityRat:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    crazypants-enderzoo-entity-EntityFallenMount:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-passive-EntityOcelot:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-projectile-EntityPotion:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    thaumcraft-common-entities-monster-EntityCultistCleric:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    thaumcraft-common-entities-monster-EntityCultistKnight:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    com-rwtema-menagerie-entities-Ents-EntityLivingArmor:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    thaumcraft-common-entities-monster-EntityGiantBrainyZombie:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    thaumcraft-common-entities-monster-EntityEldritchGuardian:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-passive-MoCEntityKitty:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-passive-EntityHorse:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    thaumcraft-common-entities-monster-EntityPech:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-monster-EntityEnderman:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    thaumcraft-common-entities-projectile-EntityEldritchOrb:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    cofh-thermalfoundation-entity-monster-EntityBlizz:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-aquatic-MoCEntityMediumFish:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-aquatic-MoCEntitySmallFish:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-minecraft-entity-effect-EntityLightningBolt:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    net-lomeli-ec-entity-EntityBigBadCreep:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    drzhark-mocreatures-entity-aquatic-MoCEntityDolphin:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    buildcraft-builders-EntityMechanicalArm:
+      tick-no-players: false
+      never-ever-tick: false
+      tick-interval: 1
+    biomesoplenty-common-entities-EntityGlob:
       tick-no-players: false
       never-ever-tick: false
       tick-interval: 1

--- a/server/tileentities.yml
+++ b/server/tileentities.yml
@@ -40,6 +40,141 @@ world-settings:
     vazkii-botania-common-block-tile-TileSpecialFlower:
       tick-no-players: false
       tick-interval: 1
+    net-minecraft-tileentity-TileEntityFurnace:
+      tick-no-players: false
+      tick-interval: 1
+    com-brandon3055-draconicevolution-common-tileentities-TilePlacedItem:
+      tick-no-players: false
+      tick-interval: 1
+    net-malisis-doors-door-tileentity-DoorTileEntity:
+      tick-no-players: false
+      tick-interval: 1
+    mods-railcraft-common-blocks-machine-alpha-TileCokeOven:
+      tick-no-players: false
+      tick-interval: 1
+    cpw-mods-ironchest-TileEntityCopperChest:
+      tick-no-players: false
+      tick-interval: 1
+    appeng-tile-grindstone-TileCrank:
+      tick-no-players: false
+      tick-interval: 1
+    mods-immibis-lxp-AbsorberTile:
+      tick-no-players: false
+      tick-interval: 1
+    vswe-production-tileentity-TileEntityTable:
+      tick-no-players: false
+      tick-interval: 1
+    mods-immibis-chunkloader-TileChunkLoader:
+      tick-no-players: false
+      tick-interval: 1
+    cpw-mods-ironchest-TileEntityIronChest:
+      tick-no-players: false
+      tick-interval: 1
+    cpw-mods-ironchest-TileEntityGoldChest:
+      tick-no-players: false
+      tick-interval: 1
+    mozeintel-projecte-gameObjs-tiles-CondenserTile:
+      tick-no-players: false
+      tick-interval: 1
+    cpw-mods-ironchest-TileEntitySilverChest:
+      tick-no-players: false
+      tick-interval: 1
+    vazkii-botania-common-block-tile-TileAltar:
+      tick-no-players: false
+      tick-interval: 1
+    vazkii-botania-common-block-tile-mana-TileSpreader:
+      tick-no-players: false
+      tick-interval: 1
+    vazkii-botania-common-block-tile-mana-TilePool:
+      tick-no-players: false
+      tick-interval: 1
+    gregtech-api-metatileentity-BaseMetaPipeEntity:
+      tick-no-players: false
+      tick-interval: 1
+    gregtech-api-metatileentity-BaseMetaTileEntity:
+      tick-no-players: false
+      tick-interval: 1
+    com-rwtema-extrautils-tileentity-transfernodes-TileEntityTransferNodeLiquid:
+      tick-no-players: false
+      tick-interval: 1
+    net-minecraft-tileentity-TileEntityHopper:
+      tick-no-players: false
+      tick-interval: 1
+    thebetweenlands-tileentities-TileEntityDruidAltar:
+      tick-no-players: false
+      tick-interval: 1
+    thebetweenlands-tileentities-spawner-TileEntityBLSpawner:
+      tick-no-players: false
+      tick-interval: 1
+    openblocks-common-tileentity-TileEntityGrave:
+      tick-no-players: false
+      tick-interval: 1
+    forestry-apiculture-tiles-TileApiary:
+      tick-no-players: false
+      tick-interval: 1
+    forestry-core-tiles-TileEscritoire:
+      tick-no-players: false
+      tick-interval: 1
+    mcjty-rftools-blocks-logic-SequencerTileEntity:
+      tick-no-players: false
+      tick-interval: 1
+    net-malisis-doors-trapdoor-tileentity-TrapDoorTileEntity:
+      tick-no-players: false
+      tick-interval: 1
+    tconstruct-smeltery-logic-CastingTableLogic:
+      tick-no-players: false
+      tick-interval: 1
+    com-xcompwiz-mystcraft-tileentity-TileEntityDesk:
+      tick-no-players: false
+      tick-interval: 1
+    com-xcompwiz-mystcraft-tileentity-TileEntityLectern:
+      tick-no-players: false
+      tick-interval: 1
+    blusunrize-immersiveengineering-common-blocks-wooden-TileEntityWoodenCrate:
+      tick-no-players: false
+      tick-interval: 1
+    tconstruct-smeltery-logic-CastingBasinLogic:
+      tick-no-players: false
+      tick-interval: 1
+    cofh-thermalexpansion-block-dynamo-TileDynamoSteam:
+      tick-no-players: false
+      tick-interval: 1
+    cofh-thermalexpansion-block-cell-TileCell:
+      tick-no-players: false
+      tick-interval: 1
+    thaumcraft-common-tiles-TileEldritchAltar:
+      tick-no-players: false
+      tick-interval: 1
+    thaumcraft-common-tiles-TileEldritchObelisk:
+      tick-no-players: false
+      tick-interval: 1
+    cofh-thermalexpansion-block-machine-TileCharger:
+      tick-no-players: false
+      tick-interval: 1
+    cofh-thermalexpansion-block-machine-TilePulverizer:
+      tick-no-players: false
+      tick-interval: 1
+    cofh-thermalexpansion-block-machine-TileFurnace:
+      tick-no-players: false
+      tick-interval: 1
+    net-minecraft-tileentity-TileEntityEnchantmentTable:
+      tick-no-players: false
+      tick-interval: 1
+    cofh-thermalexpansion-block-machine-TileSmelter:
+      tick-no-players: false
+      tick-interval: 1
+    cofh-thermalexpansion-block-dynamo-TileDynamoMagmatic:
+      tick-no-players: false
+      tick-interval: 1
+    cofh-thermalexpansion-block-machine-TileExtruder:
+      tick-no-players: false
+      tick-interval: 1
+    cofh-thermalexpansion-block-machine-TileAssembler:
+      tick-no-players: false
+      tick-interval: 1
+    StevenDimDoors-modpocketDim-tileentities-TileEntityRift:
+      tick-no-players: false
+      tick-interval: 1
     buildcraft-builders-TileQuarryCompat:
       tick-no-players: false
       tick-interval: 1
@@ -59,11 +194,5 @@ world-settings:
       tick-no-players: false
       tick-interval: 1
     com-teammetallurgy-atum-blocks-tileentity-chests-TileEntityPharaohChest:
-      tick-no-players: false
-      tick-interval: 1
-    openblocks-common-tileentity-TileEntityGrave:
-      tick-no-players: false
-      tick-interval: 1
-    com-xcompwiz-mystcraft-tileentity-TileEntityLectern:
       tick-no-players: false
       tick-interval: 1


### PR DESCRIPTION
Since it occurs frequently (from mining stone), renamed Forgotten Nature's "sulfur" to "Rock Sulfur", and added recipe to craft 64 into 1 sulfur dust from GregTech:

<img width="241" alt="screen shot 2017-07-08 at 9 56 13 am" src="https://user-images.githubusercontent.com/26856618/27987670-1adc8084-63c6-11e7-8497-426d8e81e526.png">

<img width="372" alt="screen shot 2017-07-08 at 10 10 28 am" src="https://user-images.githubusercontent.com/26856618/27987671-1e60fbae-63c6-11e7-9a81-3a88a564d821.png">

As for Natura (part of Tinkers' Construct family of mods), since its sulfur is crafted from 2x2 sulfur cloud found in the nether, added it to the ore dictionary ore:dustSulfur, so it can be used integrate with GregTech/IC2/GalaxySpace sulfur dusts.